### PR TITLE
Update dependencies to match the split SDK

### DIFF
--- a/sample-customisation/build.gradle
+++ b/sample-customisation/build.gradle
@@ -28,7 +28,7 @@ android {
 
     buildTypes {
         debug {
-            minifyEnabled true
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
         release {
@@ -40,7 +40,8 @@ android {
 }
 
 dependencies {
-    implementation "com.helpscout:beacon-sdk:+"
+    implementation "com.helpscout:beacon-core:0.0.3"
+    implementation "com.helpscout:beacon-ui:0.0.3"
 
     testImplementation "junit:junit:$jUnitVersion"
 }

--- a/sample-customisation/src/main/java/net/helpscout/sample/beacon/CustomisationActivity.java
+++ b/sample-customisation/src/main/java/net/helpscout/sample/beacon/CustomisationActivity.java
@@ -6,7 +6,7 @@ import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 
 import com.helpscout.beacon.Beacon;
-import com.helpscout.beacon.BeaconActivity;
+import com.helpscout.beacon.ui.BeaconActivity;
 
 import net.helpscout.sample.beacon.customisation.R;
 

--- a/sample-kotlin/build.gradle
+++ b/sample-kotlin/build.gradle
@@ -30,7 +30,7 @@ android {
 
     buildTypes {
         debug {
-            minifyEnabled true
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
         release {
@@ -42,8 +42,10 @@ android {
 }
 
 dependencies {
-
-    implementation "com.helpscout:beacon-sdk:+"
+    //noinspection GradleDynamicVersion
+    implementation "com.helpscout:beacon-core:0.0.3"
+    //noinspection GradleDynamicVersion
+    implementation "com.helpscout:beacon-ui:0.0.3"
 
     testImplementation "junit:junit:$jUnitVersion"
 }

--- a/sample-kotlin/src/main/kotlin/net/helpscout/samples/beacon/kotlin/MainActivity.kt
+++ b/sample-kotlin/src/main/kotlin/net/helpscout/samples/beacon/kotlin/MainActivity.kt
@@ -2,12 +2,11 @@ package net.helpscout.samples.beacon.kotlin
 
 import android.app.Activity
 import android.os.Bundle
-import android.support.design.widget.FloatingActionButton
-import android.support.v7.app.AppCompatActivity
 import android.widget.Button
 import android.widget.Toast
 import com.helpscout.beacon.Beacon
-import com.helpscout.beacon.BeaconActivity
+import com.helpscout.beacon.ui.BeaconActivity
+
 
 class MainActivity : Activity() {
 


### PR DESCRIPTION
Now we reference `core` and `ui` modules. Also the package name of the `BeaconActivity` has changed. 