### PR TITLE
Add SDKAutoInitialise meta tag to prevent core-sample crashing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,30 +5,25 @@ android:
   components:
   - platform-tools
   - tools
-  - build-tools-27.0.3
-  - android-27
+  - build-tools-28.0.3
+  - android-28
   - extra-google-google_play_services
   - extra-google-m2repository
   - extra-android-m2repository
   - addon-google_apis-google-27
 before_install:
-- yes | sdkmanager "platforms;android-27"
+  - yes | sdkmanager "platforms;android-28"
 script:
-- "./gradlew clean build"
+  - "./gradlew clean build"
 sudo: false
 before_cache:
-- rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
-- rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
 cache:
   directories:
   - "$HOME/.gradle/caches/"
   - "$HOME/.gradle/wrapper/"
   - "$HOME/.android/build-cache"
-  notifications:
-    slack: helpscout:0N9b4eViq1rxRDwtdXNtubfZ
-    on_success: change
-    on_failure: always
-    on_pull_requests: false
 env:
   global:
     secure: v+YemWkRiePrCXQCkIafyneXYwgCcwKqlHySRhH7s/X1gaAQ540jFECqHFJ4VOQqTQruGebUgPMjYLRJaaoK4aBegm2ZgK0FA/2u6zOJWvVVP93Gx+yqKAqqHqTxtngqt2AGpFdOQFio45gfjDB7Lua0lBgEDErxwe2KFCrVsEczAlnlbheBxBbZTmnFMT6m5fxb4lOv/13BQE9uHaKDYTgAn5rF2LqiBRUqy2deokYMsFMhQT0D1zByKCB08H/FTvHWnkOwcHFwFrmtc0i51mhl8aC3/qbPo1mWALAnZavqKBlvH7AJC1gTpZGQX1rFcALzUlB8d7HCjRFXDCywXkhXLUQ/kOz4lb9cCZudnNL0tW0HmKXZrMNFV/kKUyIiMTQjhOghuiBZTxh95K1ohXrWUXRAHGMs27sY1xmU/N/mfdpr0FNx7ebARah578CUbb5ZReWqOVDaieoJ1McbKJfFk50wj5v4Zyt76BHEreLR7wJuy587iEGhTCDldU7y6f1LoYRrci2wWrKaRbvCXE3U04vMjochfN8Ho80xUEhnC4lp/spW6sCNKW6fFeSUSQG5EnRr8VJwfbzkULplnWMH93HbipeqZVasTHVlJ3IP6m4rJlWKOv7PNmamTc2LH5sAH/5Q9KCYKZzYPUmB6sltB55QgwKo2Qi6Qqdl0BE=

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -8,7 +8,7 @@ ext {
 
     buildToolsVersion = '28.0.3'
     coroutinesVersion = '1.0.0'
-    gradlePluginVersion = '3.3.0'
+    gradlePluginVersion = '3.4.1'
     kotlinVersion = '1.3.11'
 
     // Testing
@@ -20,7 +20,7 @@ ext {
     constraintLayoutVersion = '1.0.2'
 
     // Beacon
-    beaconCoreVersion = '1.0.0'
-    beaconUiVersion = '1.0.0'
+    beaconCoreVersion = '1.0.1'
+    beaconUiVersion = '1.0.1'
 
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jan 17 17:33:48 GMT 2019
+#Fri May 24 15:28:15 WEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/sample-core/src/main/AndroidManifest.xml
+++ b/sample-core/src/main/AndroidManifest.xml
@@ -28,6 +28,11 @@
             android:name="com.helpscout.beacon.sample.core.CoreDetailActivity"
             android:parentActivityName="com.helpscout.beacon.sample.core.CoreListArticlesActivity"/>
 
+
+      <meta-data
+        android:name="com.helpscout.beacon.SDKAutoInitialise"
+        android:value="true" />
+
     </application>
 
 </manifest>


### PR DESCRIPTION
### :pushpin: References
#52 

### :tophat: What is the goal?

Fix the NPE crash in core-sample 

### How is it being implemented?

* Added the meta tag to the Manifest. Follow up fix in the SDK 1.0.2 to prevent this crash if meta tag not defined. 
* Updated Beacon SDK to 1.0.1
* Updated Gradle and Android plugin