### PR TITLE
ANDSDK-739 Update AGP to 7.4.2

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,7 +4,7 @@ ext {
     targetSdkVersion = 31
     compileSdkVersion = 31
 
-    gradlePluginVersion = '7.0.4'
+    gradlePluginVersion = '7.4.2'
     kotlinVersion = '1.6.21'
 
     // Testing

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip

--- a/sample-customisation/build.gradle
+++ b/sample-customisation/build.gradle
@@ -5,7 +5,7 @@ apply from: '../dependencies.gradle'
 
 android {
 
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdk rootProject.ext.compileSdkVersion
 
     defaultConfig {
         applicationId "net.helpscout.samples.beacon.customisation"
@@ -41,8 +41,7 @@ android {
         targetCompatibility JavaVersion.VERSION_11
     }
 
-
-    lintOptions {
+    lint {
         disable 'MissingTranslation'
         ignoreWarnings true
     }

--- a/sample-kotlin/build.gradle
+++ b/sample-kotlin/build.gradle
@@ -6,7 +6,7 @@ apply from: '../signing/signing.gradle'
 apply from: '../dependencies.gradle'
 
 android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdk rootProject.ext.compileSdkVersion
 
     defaultConfig {
         applicationId "net.helpscout.samples.beacon.kotlin"
@@ -51,7 +51,7 @@ android {
         jvmTarget = JavaVersion.VERSION_11.toString()
     }
 
-    lintOptions {
+    lint {
         disable 'MissingTranslation'
         ignoreWarnings true
     }


### PR DESCRIPTION
### :tophat: What is the goal?

Update AGP to 7.4.2.

### How is it being implemented?
- Android Studio Electric Eel | 2022.1.1 Patch 2
- Used AGP upgrade assistant


