### PR TITLE
MOB-7608: Prepare for release 7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Version 7.0.0 *(2026-02-26)*
 ### :warning: Breaking changes :warning:
 
 * `setFirebaseCloudMessagingToken()` now requires a `Context` as the first parameter.
+* `ContactFormConfigApi` has been renamed to `ContactFormConfig` but functionality remains unchanged.
 * `prefilledFormReset()` has been removed. Use `contactFormReset()` instead.
 * The deprecated `login()` methods have been removed. Use `identify()` instead.
 * `addAttributeWithKey()` now throws an `SDKInitException` if called before `identify()`. Previously it would silently use an empty attribute map.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,26 @@
 Change Log
 ==========
-Version 7.0.0 *(2026-02-25)*
+Version 7.0.0 *(2026-02-26)*
 ----------------------------
 
-What's new?
+### What's new?
 
 * **[AI Answers](https://docs.helpscout.com/article/1569-ai-answers)**: You can now navigate directly to the AI Answers screen using `BeaconScreens.AI_ANSWERS`, or open it with a pre-submitted question using `BeaconScreens.ASK_QUESTION`.
 * New `BeaconScreens.ANSWERS` navigation option to open directly to the docs/articles list, bypassing the Home screen.
 * New `Beacon.logout(boolean endActiveChat)` overload — pass `true` to end any active chat when the user logs out.
-* User attribute limits updated: attribute keys now support up to 100 characters (was 80) and values up to 255 characters (was 200).
+* User attribute limits updated: 
+    * Keys now support up to 100 characters (from 80) 
+    * Values up to 255 characters (from 200)
 
-:warning: Breaking changes :warning:
+### :warning: Breaking changes :warning:
 
-* The deprecated `login()` methods have been removed. Use the `identify()` methods instead.
 * `setFirebaseCloudMessagingToken()` now requires a `Context` as the first parameter.
 * `prefilledFormReset()` has been removed. Use `contactFormReset()` instead.
+* The deprecated `login()` methods have been removed. Use `identify()` instead.
 * `addAttributeWithKey()` now throws an `SDKInitException` if called before `identify()`. Previously it would silently use an empty attribute map.
 * The method `setOverrideSuggestedArticles(List<String> articleIds)` has been deprecated in favor of `setOverrideSuggestedArticlesOrLinks(List<SuggestedArticle>)`, which supports both articles and external links.
 * The maximum number of article suggestions has increased from 5 to 10.
+* Made the internal constants in `BeaconActivity` private. They weren’t intended for external use, so this shouldn’t cause any breakage.
 * Updated translation string resource IDs:
   - `hs_beacon_answers` → `hs_beacon_answer`
   - `hs_beacon_search_hint` → `hs_beacon_search`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,7 @@ Version 7.0.0 *(2026-02-26)*
 * The method `setOverrideSuggestedArticles(List<String> articleIds)` has been deprecated in favor of `setOverrideSuggestedArticlesOrLinks(List<SuggestedArticle>)`, which supports both articles and external links.
 * The maximum number of article suggestions has increased from 5 to 10.
 * Made the internal constants in `BeaconActivity` private. They weren’t intended for external use, so this shouldn’t cause any breakage.
-* Updated translation string resource IDs:
-  - `hs_beacon_answers` → `hs_beacon_answer`
-  - `hs_beacon_search_hint` → `hs_beacon_search`
-  - `hs_beacon_nothing_found` → `hs_beacon_docs_search_empty`
+* **Updated localization keys** for consistency and alignment. Some keys were renamed and others removed. See the full list of changes [here](https://developer.helpscout.com/beacon-2/android/#translation-strings).
 
 Version 6.0.1 *(2025-02-12)*
 ----------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,21 @@
 Change Log
 ==========
-Version 7.0.0 *(TBD)*
+Version 7.0.0 *(2026-02-25)*
 ----------------------------
+
+What's new?
+
+* **[AI Answers](https://docs.helpscout.com/article/1569-ai-answers)**: You can now navigate directly to the AI Answers screen using `BeaconScreens.AI_ANSWERS`, or open it with a pre-submitted question using `BeaconScreens.ASK_QUESTION`.
+* New `BeaconScreens.ANSWERS` navigation option to open directly to the docs/articles list, bypassing the Home screen.
+* New `Beacon.logout(boolean endActiveChat)` overload — pass `true` to end any active chat when the user logs out.
+* User attribute limits updated: attribute keys now support up to 100 characters (was 80) and values up to 255 characters (was 200).
+
 :warning: Breaking changes :warning:
 
+* The deprecated `login()` methods have been removed. Use the `identify()` methods instead.
+* `setFirebaseCloudMessagingToken()` now requires a `Context` as the first parameter.
+* `prefilledFormReset()` has been removed. Use `contactFormReset()` instead.
+* `addAttributeWithKey()` now throws an `SDKInitException` if called before `identify()`. Previously it would silently use an empty attribute map.
 * The method `setOverrideSuggestedArticles(List<String> articleIds)` has been deprecated in favor of `setOverrideSuggestedArticlesOrLinks(List<SuggestedArticle>)`, which supports both articles and external links.
 * The maximum number of article suggestions has increased from 5 to 10.
 * Updated translation string resource IDs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 Change Log
 ==========
+Version 7.0.0 *(TBD)*
+----------------------------
+:warning: Breaking changes :warning:
+
+* The method `setOverrideSuggestedArticles(List<String> articleIds)` has been deprecated in favor of `setOverrideSuggestedArticlesOrLinks(List<SuggestedArticle>)`, which supports both articles and external links.
+* The maximum number of article suggestions has increased from 5 to 10.
+* Updated translation string resource IDs:
+  - `hs_beacon_answers` → `hs_beacon_answer`
+  - `hs_beacon_search_hint` → `hs_beacon_search`
+  - `hs_beacon_nothing_found` → `hs_beacon_docs_search_empty`
+
 Version 6.0.1 *(2025-02-12)*
 ----------------------------
 Bugfixes:

--- a/README.md
+++ b/README.md
@@ -27,9 +27,8 @@ You can subscribe to receive release updates by following these steps:
 ### Supported platform and language versions
 
 * Android 11.0 to 15.0 (as noted above the "minSdkVersion: 21 (Android 5.0)" for greater compatibility however we only offer support for issues on Android 11+)
-* Kotlin 1.8.20
-* Java 11
-* Koin 3.4.2
+* Kotlin 2.1.0
+* Java 17
 
 ## Installation
 The Beacon Android SDK is distributed as AAR and available from Maven Central, so add the following lines to your app's `build.gradle` file.

--- a/sample-customisation/src/main/java/net/helpscout/sample/beacon/CustomisationActivity.java
+++ b/sample-customisation/src/main/java/net/helpscout/sample/beacon/CustomisationActivity.java
@@ -10,6 +10,7 @@ import com.helpscout.beacon.Beacon;
 import com.helpscout.beacon.internal.core.model.ContactFormConfigApi;
 import com.helpscout.beacon.model.BeaconConfigOverrides;
 import com.helpscout.beacon.model.PreFilledForm;
+import com.helpscout.beacon.model.SuggestedArticle;
 import com.helpscout.beacon.ui.BeaconActivity;
 import net.helpscout.sample.beacon.util.Utils;
 
@@ -126,17 +127,17 @@ public class CustomisationActivity extends AppCompatActivity {
     }
 
     /**
-     * Replace the Instant Answers (suggestions) with this list. Note: max 5
+     * Replace the Instant Answers (suggestions) with this list. Note: max 10
      * More info: https://developer.helpscout.com/beacon-2/android/#custom-suggestions
      */
     private void overrideInstantAnswers(boolean enabled) {
         if (enabled) {
-            List<String> overrides = new ArrayList<>();
+            List<SuggestedArticle> overrides = new ArrayList<>();
             // TODO replace the article IDs with Articles from your Docs Collection.
             // https://secure.helpscout.net/docs/[COLLECTION ID]/article/[ARTICLE ID]/
-            overrides.add("11122bbb0428631d7a89ff4a");
-            overrides.add("11122ffd2c7d3a0fa9a29d22");
-            Beacon.setOverrideSuggestedArticles(overrides);
+            overrides.add(new SuggestedArticle.SuggestedArticleWithId("11122bbb0428631d7a89ff4a"));
+            overrides.add(new SuggestedArticle.SuggestedArticleWithId("11122ffd2c7d3a0fa9a29d22"));
+            Beacon.setOverrideSuggestedArticlesOrLinks(overrides);
         } else {
             Beacon.resetSuggestedArticlesOverrides();
         }

--- a/sample-customisation/src/main/java/net/helpscout/sample/beacon/CustomisationActivity.java
+++ b/sample-customisation/src/main/java/net/helpscout/sample/beacon/CustomisationActivity.java
@@ -9,6 +9,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import com.helpscout.beacon.Beacon;
 import com.helpscout.beacon.internal.core.model.ContactFormConfigApi;
 import com.helpscout.beacon.model.BeaconConfigOverrides;
+import com.helpscout.beacon.model.ContactFormConfig;
 import com.helpscout.beacon.model.PreFilledForm;
 import com.helpscout.beacon.model.SuggestedArticle;
 import com.helpscout.beacon.ui.BeaconActivity;
@@ -116,11 +117,12 @@ public class CustomisationActivity extends AppCompatActivity {
                 true, // docsEnabled
                 true, // messagingEnabled
                 true, // chatEnabled
-                new ContactFormConfigApi(  // ContactForm overrides
+                new ContactFormConfig(  // ContactForm overrides
                         shouldDisableName, // showName
                         shouldDisableSubject, // showSubject
                         true,  // allowAttachments
                         false // customFieldsEnabled
+
                 ),
                 colorOverride  // override color in #000000 format
         ));

--- a/sample-customisation/src/main/res/values-es/beacon-override.xml
+++ b/sample-customisation/src/main/res/values-es/beacon-override.xml
@@ -3,8 +3,8 @@
     This file demonstrates overriding some of the Beacon strings for Español
     See https://developer.helpscout.com/beacon-2/android/#translation-strings for full list
    -->
-  <string name="hs_beacon_answers">Respuestas</string>
-  <string name="hs_beacon_search_hint">¿Cómo te podemos ayudar?</string>
-  <string name="hs_beacon_nothing_found">No hemos encontrado ningún artículo que coincida con tu búsqueda</string>
+  <string name="hs_beacon_answer">Respuestas</string>
+  <string name="hs_beacon_search">¿Cómo te podemos ayudar?</string>
+  <string name="hs_beacon_docs_search_empty">No hemos encontrado ningún artículo que coincida con tu búsqueda</string>
 
 </resources>

--- a/sample-customisation/src/main/res/values/beacon-override.xml
+++ b/sample-customisation/src/main/res/values/beacon-override.xml
@@ -3,8 +3,8 @@
     This file demonstrates overriding some of the Beacon strings
     See https://developer.helpscout.com/beacon-2/android/#translation-strings for full list
    -->
-  <string name="hs_beacon_answers">Customised</string>
-  <string name="hs_beacon_search_hint">Customised hint</string>
-  <string name="hs_beacon_nothing_found">Customised nothing found</string>
+  <string name="hs_beacon_answer">Customised</string>
+  <string name="hs_beacon_search">Customised hint</string>
+  <string name="hs_beacon_docs_search_empty">Customised nothing found</string>
 
 </resources>


### PR DESCRIPTION
### :tophat: What is the goal?

Update the sample apps to demonstrate the migration from Beacon SDK v6.0.1 to v7.0.0, showcasing the breaking changes and new APIs introduced in v7.0.0.

### How is it being implemented?

- Migrated from deprecated `setOverrideSuggestedArticles(List<String>)` to new `setOverrideSuggestedArticlesOrLinks(List<SuggestedArticle>)`
- Updated comment to reflect new maximum of 10 suggestions (increased from 5)
- Updated string resource IDs:
      - `hs_beacon_answers` → `hs_beacon_answer`
      - `hs_beacon_search_hint` → `hs_beacon_search`
      - `hs_beacon_nothing_found` → `hs_beacon_docs_search_empty`
- Updated CHANGELOG.md

### Pending
Once we schedule the release date, we need to update the CHANGELOG.md – I left a TBD placeholder for setting the release data
